### PR TITLE
Update .config file

### DIFF
--- a/.config
+++ b/.config
@@ -28,6 +28,12 @@ CONFIG_DRIVER_PRISM54=y
 # Driver interface for drivers using the nl80211 kernel interface
 CONFIG_DRIVER_NL80211=y
 
+# driver_nl80211.c requires libnl. If you are compiling it yourself
+# you may need to point hostapd to your version of libnl.
+#
+#CFLAGS += -I$<path to libnl include files>
+#LIBS += -L$<path to libnl library files>
+
 # Use libnl v2.0 (or 3.0) libraries.
 #CONFIG_LIBNL20=y
 
@@ -37,7 +43,6 @@ CONFIG_LIBNL32=y
 
 # Driver interface for FreeBSD net80211 layer (e.g., Atheros driver)
 #CONFIG_DRIVER_BSD=y
-#CONFIG_SUPPORT_RTW_DRIVER=y
 #CFLAGS += -I/usr/local/include
 #LIBS += -L/usr/local/lib
 #LIBS_p += -L/usr/local/lib
@@ -56,9 +61,6 @@ CONFIG_RSN_PREAUTH=y
 CONFIG_PEERKEY=y
 
 # IEEE 802.11w (management frame protection)
-# This version is an experimental implementation based on IEEE 802.11w/D1.0
-# draft and is subject to change since the standard has not yet been finalized.
-# Driver support is also needed for IEEE 802.11w.
 CONFIG_IEEE80211W=y
 
 # Integrated EAP server
@@ -98,6 +100,9 @@ CONFIG_EAP_PAX=y
 # EAP-PSK for the integrated EAP server (this is _not_ needed for WPA-PSK)
 CONFIG_EAP_PSK=y
 
+# EAP-pwd for the integrated EAP server (secure authentication with a password)
+#CONFIG_EAP_PWD=y
+
 # EAP-SAKE for the integrated EAP server
 CONFIG_EAP_SAKE=y
 
@@ -107,24 +112,26 @@ CONFIG_EAP_GPSK=y
 CONFIG_EAP_GPSK_SHA256=y
 
 # EAP-FAST for the integrated EAP server
-# Note: Default OpenSSL package does not include support for all the
-# functionality needed for EAP-FAST. If EAP-FAST is enabled with OpenSSL,
-# the OpenSSL library must be patched (openssl-0.9.9-session-ticket.patch)
-# to add the needed functions.
+# Note: If OpenSSL is used as the TLS library, OpenSSL 1.0 or newer is needed
+# for EAP-FAST support. Older OpenSSL releases would need to be patched, e.g.,
+# with openssl-0.9.8x-tls-extensions.patch, to add the needed functions.
 #CONFIG_EAP_FAST=y
 
 # Wi-Fi Protected Setup (WPS)
 CONFIG_WPS=y
-# Enable WSC 2.0 support
-#CONFIG_WPS2=y
 # Enable UPnP support for external WPS Registrars
 #CONFIG_WPS_UPNP=y
+# Enable WPS support with NFC config method
+#CONFIG_WPS_NFC=y
 
 # EAP-IKEv2
 #CONFIG_EAP_IKEV2=y
 
 # Trusted Network Connect (EAP-TNC)
 #CONFIG_EAP_TNC=y
+
+# EAP-EKE for the integrated EAP server
+#CONFIG_EAP_EKE=y
 
 # PKCS#12 (PFX) support (used to read private key and certificate file from
 # a file that usually has extension .p12 or .pfx)
@@ -147,6 +154,10 @@ CONFIG_IPV6=y
 # IEEE 802.11n (High Throughput) support
 CONFIG_IEEE80211N=y
 
+# Wireless Network Management (IEEE Std 802.11v-2011)
+# Note: This is experimental and not complete implementation.
+#CONFIG_WNM=y
+
 # IEEE 802.11ac (Very High Throughput) support
 CONFIG_IEEE80211AC=y
 
@@ -158,6 +169,12 @@ CONFIG_IEEE80211AC=y
 # Add support for writing debug log to a file: -f /tmp/hostapd.log
 # Disabled by default.
 #CONFIG_DEBUG_FILE=y
+
+# Add support for sending all debug messages (regardless of debug verbosity)
+# to the Linux kernel tracing facility. This helps debug the entire stack by
+# making it easy to record everything happening from the driver up into the
+# same file, e.g., using trace-cmd.
+#CONFIG_DEBUG_LINUX_TRACING=y
 
 # Remove support for RADIUS accounting
 #CONFIG_NO_ACCOUNTING=y
@@ -172,7 +189,11 @@ CONFIG_IEEE80211AC=y
 # automatically create bridge and VLAN interfaces if necessary.
 #CONFIG_FULL_DYNAMIC_VLAN=y
 
-# Remove support for dumping state into a file on SIGUSR1 signal
+# Use netlink-based kernel API for VLAN operations instead of ioctl()
+# Note: This requires libnl 3.1 or newer.
+#CONFIG_VLAN_NETLINK=y
+
+# Remove support for dumping internal state through control interface commands
 # This can be used to reduce binary size at the cost of disabling a debugging
 # option.
 #CONFIG_NO_DUMP_STATE=y
@@ -210,15 +231,72 @@ CONFIG_IEEE80211AC=y
 # it may help in cases where the system pool is not initialized properly.
 # However, it is very strongly recommended that the system pool is initialized
 # with enough entropy either by using hardware assisted random number
-# generatior or by storing state over device reboots.
+# generator or by storing state over device reboots.
 #
-# If the os_get_random() is known to provide strong ramdom data (e.g., on
+# hostapd can be configured to maintain its own entropy store over restarts to
+# enhance random number generation. This is not perfect, but it is much more
+# secure than using the same sequence of random numbers after every reboot.
+# This can be enabled with -e<entropy file> command line option. The specified
+# file needs to be readable and writable by hostapd.
+#
+# If the os_get_random() is known to provide strong random data (e.g., on
 # Linux/BSD, the board in question is known to have reliable source of random
 # data from /dev/urandom), the internal hostapd random pool can be disabled.
 # This will save some in binary size and CPU use. However, this should only be
 # considered for builds that are known to be used on devices that meet the
 # requirements described above.
 #CONFIG_NO_RANDOM_POOL=y
+
+# Select TLS implementation
+# openssl = OpenSSL (default)
+# gnutls = GnuTLS
+# internal = Internal TLSv1 implementation (experimental)
+# none = Empty template
+#CONFIG_TLS=openssl
+
+# TLS-based EAP methods require at least TLS v1.0. Newer version of TLS (v1.1)
+# can be enabled to get a stronger construction of messages when block ciphers
+# are used.
+#CONFIG_TLSV11=y
+
+# TLS-based EAP methods require at least TLS v1.0. Newer version of TLS (v1.2)
+# can be enabled to enable use of stronger crypto algorithms.
+#CONFIG_TLSV12=y
+
+# If CONFIG_TLS=internal is used, additional library and include paths are
+# needed for LibTomMath. Alternatively, an integrated, minimal version of
+# LibTomMath can be used. See beginning of libtommath.c for details on benefits
+# and drawbacks of this option.
+#CONFIG_INTERNAL_LIBTOMMATH=y
+#ifndef CONFIG_INTERNAL_LIBTOMMATH
+#LTM_PATH=/usr/src/libtommath-0.39
+#CFLAGS += -I$(LTM_PATH)
+#LIBS += -L$(LTM_PATH)
+#LIBS_p += -L$(LTM_PATH)
+#endif
+# At the cost of about 4 kB of additional binary size, the internal LibTomMath
+# can be configured to include faster routines for exptmod, sqr, and div to
+# speed up DH and RSA calculation considerably
+#CONFIG_INTERNAL_LIBTOMMATH_FAST=y
+
+# Interworking (IEEE 802.11u)
+# This can be used to enable functionality to improve interworking with
+# external networks.
+#CONFIG_INTERWORKING=y
+
+# Hotspot 2.0
+#CONFIG_HS20=y
+
+# Enable SQLite database support in hlr_auc_gw, EAP-SIM DB, and eap_user_file
+#CONFIG_SQLITE=y
+
+# Testing options
+# This can be used to enable some testing options (see also the example
+# configuration file) that are really useful only for testing clients that
+# connect to this hostapd. These options allow, for example, to drop a
+# certain percentage of probe requests or auth/(re)assoc frames.
+#
+#CONFIG_TESTING_OPTIONS=y
 
 # Automatic Channel Selection
 # This will allow hostapd to pick the channel automatically when channel is set

--- a/.config
+++ b/.config
@@ -10,18 +10,30 @@
 # to override previous values of the variables.
 
 # Driver interface for Host AP driver
-#CONFIG_DRIVER_HOSTAP=y
+CONFIG_DRIVER_HOSTAP=y
+
+# Driver rtl871xdrv
 CONFIG_DRIVER_RTW=y
 
 # Driver interface for wired authenticator
-#CONFIG_DRIVER_WIRED=y
+CONFIG_DRIVER_WIRED=y
+
+# Driver interface for Prism54 driver
+CONFIG_DRIVER_PRISM54=y
 
 # Driver interface for madwifi driver
 #CONFIG_DRIVER_MADWIFI=y
 #CFLAGS += -I../../madwifi # change to the madwifi source directory
 
 # Driver interface for drivers using the nl80211 kernel interface
-#CONFIG_DRIVER_NL80211=y
+CONFIG_DRIVER_NL80211=y
+
+# Use libnl v2.0 (or 3.0) libraries.
+#CONFIG_LIBNL20=y
+
+# Use libnl 3.2 libraries (if this is selected, CONFIG_LIBNL20 is ignored)
+CONFIG_LIBNL32=y
+
 
 # Driver interface for FreeBSD net80211 layer (e.g., Atheros driver)
 #CONFIG_DRIVER_BSD=y
@@ -35,64 +47,64 @@ CONFIG_DRIVER_RTW=y
 #CONFIG_DRIVER_NONE=y
 
 # IEEE 802.11F/IAPP
-#CONFIG_IAPP=y
+CONFIG_IAPP=y
 
 # WPA2/IEEE 802.11i RSN pre-authentication
-#CONFIG_RSN_PREAUTH=y
+CONFIG_RSN_PREAUTH=y
 
 # PeerKey handshake for Station to Station Link (IEEE 802.11e DLS)
-#CONFIG_PEERKEY=y
+CONFIG_PEERKEY=y
 
 # IEEE 802.11w (management frame protection)
 # This version is an experimental implementation based on IEEE 802.11w/D1.0
 # draft and is subject to change since the standard has not yet been finalized.
 # Driver support is also needed for IEEE 802.11w.
-#CONFIG_IEEE80211W=y
+CONFIG_IEEE80211W=y
 
 # Integrated EAP server
 CONFIG_EAP=y
 
 # EAP-MD5 for the integrated EAP server
-#CONFIG_EAP_MD5=y
+CONFIG_EAP_MD5=y
 
 # EAP-TLS for the integrated EAP server
-#CONFIG_EAP_TLS=y
+CONFIG_EAP_TLS=y
 
 # EAP-MSCHAPv2 for the integrated EAP server
-#CONFIG_EAP_MSCHAPV2=y
+CONFIG_EAP_MSCHAPV2=y
 
 # EAP-PEAP for the integrated EAP server
-#CONFIG_EAP_PEAP=y
+CONFIG_EAP_PEAP=y
 
 # EAP-GTC for the integrated EAP server
-#CONFIG_EAP_GTC=y
+CONFIG_EAP_GTC=y
 
 # EAP-TTLS for the integrated EAP server
-#CONFIG_EAP_TTLS=y
+CONFIG_EAP_TTLS=y
 
 # EAP-SIM for the integrated EAP server
-#CONFIG_EAP_SIM=y
+CONFIG_EAP_SIM=y
 
 # EAP-AKA for the integrated EAP server
-#CONFIG_EAP_AKA=y
+CONFIG_EAP_AKA=y
 
 # EAP-AKA' for the integrated EAP server
 # This requires CONFIG_EAP_AKA to be enabled, too.
 #CONFIG_EAP_AKA_PRIME=y
 
 # EAP-PAX for the integrated EAP server
-#CONFIG_EAP_PAX=y
+CONFIG_EAP_PAX=y
 
 # EAP-PSK for the integrated EAP server (this is _not_ needed for WPA-PSK)
-#CONFIG_EAP_PSK=y
+CONFIG_EAP_PSK=y
 
 # EAP-SAKE for the integrated EAP server
-#CONFIG_EAP_SAKE=y
+CONFIG_EAP_SAKE=y
 
 # EAP-GPSK for the integrated EAP server
-#CONFIG_EAP_GPSK=y
+CONFIG_EAP_GPSK=y
 # Include support for optional SHA256 cipher suite in EAP-GPSK
-#CONFIG_EAP_GPSK_SHA256=y
+CONFIG_EAP_GPSK_SHA256=y
 
 # EAP-FAST for the integrated EAP server
 # Note: Default OpenSSL package does not include support for all the
@@ -108,9 +120,6 @@ CONFIG_WPS=y
 # Enable UPnP support for external WPS Registrars
 #CONFIG_WPS_UPNP=y
 
-CONFIG_TLS=internal
-CONFIG_INTERNAL_LIBTOMMATH=y
-
 # EAP-IKEv2
 #CONFIG_EAP_IKEV2=y
 
@@ -119,14 +128,14 @@ CONFIG_INTERNAL_LIBTOMMATH=y
 
 # PKCS#12 (PFX) support (used to read private key and certificate file from
 # a file that usually has extension .p12 or .pfx)
-#CONFIG_PKCS12=y
+CONFIG_PKCS12=y
 
 # RADIUS authentication server. This provides access to the integrated EAP
 # server from external hosts using RADIUS.
-#CONFIG_RADIUS_SERVER=y
+CONFIG_RADIUS_SERVER=y
 
 # Build IPv6 support for RADIUS operations
-#CONFIG_IPV6=y
+CONFIG_IPV6=y
 
 # IEEE Std 802.11r-2008 (Fast BSS Transition)
 #CONFIG_IEEE80211R=y
@@ -137,6 +146,9 @@ CONFIG_INTERNAL_LIBTOMMATH=y
 
 # IEEE 802.11n (High Throughput) support
 CONFIG_IEEE80211N=y
+
+# IEEE 802.11ac (Very High Throughput) support
+CONFIG_IEEE80211AC=y
 
 # Remove debugging code that is printing out debug messages to stdout.
 # This can be used to reduce the size of the hostapd considerably if debugging
@@ -207,3 +219,27 @@ CONFIG_IEEE80211N=y
 # considered for builds that are known to be used on devices that meet the
 # requirements described above.
 #CONFIG_NO_RANDOM_POOL=y
+
+# Automatic Channel Selection
+# This will allow hostapd to pick the channel automatically when channel is set
+# to "acs_survey" or "0". Eventually, other ACS algorithms can be added in
+# similar way.
+#
+# Automatic selection is currently only done through initialization, later on
+# we hope to do background checks to keep us moving to more ideal channels as
+# time goes by. ACS is currently only supported through the nl80211 driver and
+# your driver must have survey dump capability that is filled by the driver
+# during scanning.
+#
+# You can customize the ACS survey algorithm with the hostapd.conf variable
+# acs_num_scans.
+#
+# Supported ACS drivers:
+# * ath9k
+# * ath5k
+# * ath10k
+#
+# For more details refer to:
+# http://wireless.kernel.org/en/users/Documentation/acs
+#
+CONFIG_ACS=y


### PR DESCRIPTION
Hi,

The config that you provide it disables a lot of features and it creates a hostapd that can be use only with rtl871xdrv.
I took the config options that ArchLinux use and I enabled them in the config file. With this you can use hostapd with or without rtl871xdrv.
I also updated the comments of the config from the default config of hostapd.