### PR TITLE
Remove redundant function wext_signal_poll()

### DIFF
--- a/rtlxdrv.patch
+++ b/rtlxdrv.patch
@@ -499,41 +499,6 @@ index e5734bd..80f073d 100644
  	os_memset(&iwr, 0, sizeof(iwr));
  	os_strlcpy(iwr.ifr_name, drv->ifname, IFNAMSIZ);
  
-@@ -2315,6 +2351,28 @@ static const char * wext_get_radio_name(void *priv)
- 	return drv->phyname;
- }
- 
-+//	Aries 20120120,  append rssi information at the end of "status" command
-+int wext_signal_poll(void *priv, struct wpa_signal_info *signal_info)
-+{
-+	struct wpa_driver_wext_data *drv = priv;
-+	struct iwreq iwr;
-+	struct iw_statistics stat;
-+	int ret = 0;
-+
-+	os_memset(&iwr, 0, sizeof(iwr));
-+	os_memset(&stat, 0, sizeof(stat));
-+	os_strlcpy(iwr.ifr_name, drv->ifname, IFNAMSIZ);
-+	iwr.u.data.pointer = (caddr_t) &stat;
-+	iwr.u.data.length = sizeof(struct iw_statistics);
-+	iwr.u.data.flags = 1;
-+	if (ioctl(drv->ioctl_sock, SIOCGIWSTATS, &iwr) < 0) {
-+		perror("ioctl[SIOCGIWSTATS] fail\n");
-+		ret = -1;
-+	}
-+	signal_info->current_signal = stat.qual.level;
-+	signal_info->current_noise = stat.qual.noise;
-+	return ret;
-+}
- 
- const struct wpa_driver_ops wpa_driver_wext_ops = {
- 	.name = "wext",
-@@ -2335,4 +2393,5 @@ const struct wpa_driver_ops wpa_driver_wext_ops = {
- 	.get_capa = wpa_driver_wext_get_capa,
- 	.set_operstate = wpa_driver_wext_set_operstate,
- 	.get_radio_name = wext_get_radio_name,
-+	.signal_poll = wext_signal_poll,
- };
 diff --git a/src/drivers/drivers.c b/src/drivers/drivers.c
 index d0e42ec..d413c00 100644
 --- a/src/drivers/drivers.c


### PR DESCRIPTION
The current patch does not apply cleanly to hostapd-2.5. The function
wpa_driver_wext_signal_poll() in src/drivers/driver_wext.c is
equivalent to wext_signal_poll() from the patch. Removing this function
fixes the problem.