### PR TITLE
Add hostapd 2.9 support from  archlinux

### DIFF
--- a/hostapd-noscan.patch
+++ b/hostapd-noscan.patch
@@ -1,0 +1,76 @@
+diff -wbBur hostapd-2.8/hostapd/config_file.c hostapd-2.8.q/hostapd/config_file.c
+--- hostapd-2.8/hostapd/config_file.c	2019-04-21 10:10:22.000000000 +0300
++++ hostapd-2.8.q/hostapd/config_file.c	2019-04-25 14:59:57.594749041 +0300
+@@ -2858,6 +2858,8 @@
+ 		bss->wpa_gmk_rekey = atoi(pos);
+ 	} else if (os_strcmp(buf, "wpa_ptk_rekey") == 0) {
+ 		bss->wpa_ptk_rekey = atoi(pos);
++	} else if (os_strcmp(buf, "noscan") == 0) {
++		conf->noscan = atoi(pos);
+ 	} else if (os_strcmp(buf, "wpa_group_update_count") == 0) {
+ 		char *endp;
+ 		unsigned long val = strtoul(pos, &endp, 0);
+@@ -3390,6 +3392,8 @@
+ 			bss->ieee80211w = 1;
+ #endif /* CONFIG_OCV */
+ #ifdef CONFIG_IEEE80211N
++	} else if (os_strcmp(buf, "noscan") == 0) {
++		conf->noscan = atoi(pos);
+ 	} else if (os_strcmp(buf, "ieee80211n") == 0) {
+ 		conf->ieee80211n = atoi(pos);
+ 	} else if (os_strcmp(buf, "ht_capab") == 0) {
+diff -wbBur hostapd-2.8/src/ap/ap_config.h hostapd-2.8.q/src/ap/ap_config.h
+--- hostapd-2.8/src/ap/ap_config.h	2019-04-21 10:10:22.000000000 +0300
++++ hostapd-2.8.q/src/ap/ap_config.h	2019-04-25 15:01:32.981414600 +0300
+@@ -801,6 +801,7 @@
+ 
+ 	int ht_op_mode_fixed;
+ 	u16 ht_capab;
++	int noscan;
+ 	int ieee80211n;
+ 	int secondary_channel;
+ 	int no_pri_sec_switch;
+diff -wbBur hostapd-2.8/src/ap/hw_features.c hostapd-2.8.q/src/ap/hw_features.c
+--- hostapd-2.8/src/ap/hw_features.c	2019-04-21 10:10:22.000000000 +0300
++++ hostapd-2.8.q/src/ap/hw_features.c	2019-04-25 14:58:10.278083605 +0300
+@@ -477,7 +477,7 @@
+ 	int ret;
+ 
+ 	/* Check that HT40 is used and PRI / SEC switch is allowed */
+-	if (!iface->conf->secondary_channel || iface->conf->no_pri_sec_switch)
++	if (!iface->conf->secondary_channel || iface->conf->no_pri_sec_switch || iface->conf->noscan)
+ 		return 0;
+ 
+ 	hostapd_set_state(iface, HAPD_IFACE_HT_SCAN);
+@@ -730,7 +730,7 @@
+ 	if (!hostapd_is_usable_chan(iface, iface->conf->channel, 1))
+ 		return 0;
+ 
+-	if (!iface->conf->secondary_channel)
++	if (!iface->conf->secondary_channel || iface->conf->noscan)
+ 		return 1;
+ 
+ 	if (!iface->conf->ht40_plus_minus_allowed)
+diff -wbBur hostapd-2.8/src/ap/ieee802_11_ht.c hostapd-2.8.q/src/ap/ieee802_11_ht.c
+--- hostapd-2.8/src/ap/ieee802_11_ht.c	2019-04-21 10:10:22.000000000 +0300
++++ hostapd-2.8.q/src/ap/ieee802_11_ht.c	2019-04-25 14:58:10.278083605 +0300
+@@ -252,6 +252,9 @@
+ 		return;
+ 	}
+ 
++	if (iface->conf->noscan)
++		return;
++
+ 	if (len < IEEE80211_HDRLEN + 2 + sizeof(*bc_ie)) {
+ 		wpa_printf(MSG_DEBUG,
+ 			   "Ignore too short 20/40 BSS Coexistence Management frame");
+@@ -412,6 +415,9 @@
+ 	if (iface->current_mode->mode != HOSTAPD_MODE_IEEE80211G)
+ 		return;
+ 
++	if (iface->conf->noscan)
++		return;
++
+ 	wpa_printf(MSG_INFO, "HT: Forty MHz Intolerant is set by STA " MACSTR
+ 		   " in Association Request", MAC2STR(sta->addr));
+ 

--- a/openvswitch.patch
+++ b/openvswitch.patch
@@ -1,0 +1,137 @@
+diff -wbBur hostapd-2.8.q/src/drivers/drivers.mak hostapd-2.8/src/drivers/drivers.mak
+--- hostapd-2.8.q/src/drivers/drivers.mak	2019-04-21 10:10:22.000000000 +0300
++++ hostapd-2.8/src/drivers/drivers.mak	2019-04-25 15:05:36.981411804 +0300
+@@ -136,6 +136,10 @@
+ NEED_RFKILL=y
+ endif
+ 
++ifdef CONFIG_OPENVSWITCH
++DRV_CFLAGS += -DCONFIG_OPENVSWITCH
++endif
++
+ ifdef NEED_NETLINK
+ DRV_OBJS += ../src/drivers/netlink.o
+ endif
+diff -wbBur hostapd-2.8.q/src/drivers/drivers.mk hostapd-2.8/src/drivers/drivers.mk
+--- hostapd-2.8.q/src/drivers/drivers.mk	2019-04-21 10:10:22.000000000 +0300
++++ hostapd-2.8/src/drivers/drivers.mk	2019-04-25 15:05:36.981411804 +0300
+@@ -128,6 +128,10 @@
+ NEED_RFKILL=y
+ endif
+ 
++ifdef CONFIG_OPENVSWITCH
++DRV_CFLAGS += -DCONFIG_OPENVSWITCH
++endif
++
+ ifdef NEED_NETLINK
+ DRV_OBJS += src/drivers/netlink.c
+ endif
+diff -wbBur hostapd-2.8.q/src/drivers/linux_ioctl.c hostapd-2.8/src/drivers/linux_ioctl.c
+--- hostapd-2.8.q/src/drivers/linux_ioctl.c	2019-04-21 10:10:22.000000000 +0300
++++ hostapd-2.8/src/drivers/linux_ioctl.c	2019-04-25 15:05:36.981411804 +0300
+@@ -15,6 +15,69 @@
+ #include "common/linux_bridge.h"
+ #include "linux_ioctl.h"
+ 
++#ifdef CONFIG_OPENVSWITCH
++#include <sys/wait.h>
++#include <sys/stat.h>
++
++#define run_prog(p, ...) ({ \
++	struct stat q; \
++	int rc = -1, status; \
++	if(stat(p, &q) == 0) \
++	{ \
++		pid_t pid = fork(); \
++		if (!pid) \
++			exit(execl(p, p, ##__VA_ARGS__, NULL)); \
++		if (pid < 0) { \
++			rc = -1; \
++		} else { \
++			while ((rc = waitpid(pid, &status, 0)) == -1 && errno == EINTR); \
++			rc = (rc == pid && WIFEXITED(status)) ? WEXITSTATUS(status) : -1; \
++		} \
++	} \
++	rc; \
++})
++
++int ovs_br_get(char *brname, const char *ifname)
++{
++	FILE *f;
++	char cmd[64];
++	char *c;
++	struct stat q;
++
++	if(stat("/usr/bin/ovs-vsctl", &q) != 0)
++		return -1;
++
++	brname[0] = '\0';
++	sprintf(cmd, "/usr/bin/ovs-vsctl iface-to-br %s", ifname);
++	f = popen(cmd, "r");
++	if (!f)
++		return -1;
++	c = fgets(brname, IFNAMSIZ, f);
++	pclose(f);
++	if (c && strlen(brname)) {
++		/* Ignore newline */
++		if ((c = strchr(brname, '\n')))
++			*c = '\0';
++		return 0;
++	}
++	return -1;
++}
++
++int ovs_br_add_if(const char *brname, const char *ifname)
++{
++	if (run_prog("/usr/bin/ovs-vsctl", "add-port", brname, ifname))
++		return -1;
++	return 0;
++}
++
++int ovs_br_del_if(const char *brname, const char *ifname)
++{
++	if (run_prog("/usr/bin/ovs-vsctl", "del-port", brname, ifname))
++		return -1;
++	return 0;
++}
++
++#endif
+ 
+ int linux_set_iface_flags(int sock, const char *ifname, int dev_up)
+ {
+@@ -152,6 +215,11 @@
+ 	struct ifreq ifr;
+ 	int ifindex;
+ 
++#ifdef CONFIG_OPENVSWITCH
++	if (!ovs_br_add_if(brname, ifname))
++		return 0;
++#endif
++
+ 	ifindex = if_nametoindex(ifname);
+ 	if (ifindex == 0)
+ 		return -1;
+@@ -177,6 +245,11 @@
+ 	struct ifreq ifr;
+ 	int ifindex;
+ 
++#ifdef CONFIG_OPENVSWITCH
++	if (!ovs_br_del_if(brname, ifname))
++		return 0;
++#endif
++
+ 	ifindex = if_nametoindex(ifname);
+ 	if (ifindex == 0)
+ 		return -1;
+@@ -199,6 +272,11 @@
+ 	char path[128], brlink[128], *pos;
+ 	ssize_t res;
+ 
++#ifdef CONFIG_OPENVSWITCH
++	if (!ovs_br_get(brname, ifname))
++		return 0;
++#endif
++
+ 	os_snprintf(path, sizeof(path), "/sys/class/net/%s/brport/bridge",
+ 		    ifname);
+ 	res = readlink(path, brlink, sizeof(brlink));


### PR DESCRIPTION
https://aur.archlinux.org/packages/hostapd-rtl871xdrv/

Compiles and tests on 2.9 with 8814au and 8822BU cards. However
the need for this driver is questionable since the default one
supports the same features. But maybe there is something.

To patch:
patch -p1 -i <path>hostapd-noscan.patch
patch -p1 -i <path>openvswitch.patch
patch -Np1 -i <path>rtlxdrv.patch